### PR TITLE
Fix for when 'pairs' is not returned

### DIFF
--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -44,16 +44,22 @@ class DexscreenerClient:
             Response as list of TokenPair model
         """
         resp = self._client.request("GET",  f"dex/tokens/{address}")
-
-        return [TokenPair(**pair) for pair in resp["pairs"]]
+        
+        if resp["pairs"]:
+            return [TokenPair(**pair) for pair in resp["pairs"]]
+        else:
+            return []
 
     async def get_token_pairs_async(self, address: str) -> list[TokenPair]:
         """
         Async version of `get_token_pairs`
         """
         resp = await self._client.request_async("GET", f"dex/tokens/{address}")
-
-        return [TokenPair(**pair) for pair in resp["pairs"]]
+        
+        if resp["pairs"]:        
+            return [TokenPair(**pair) for pair in resp["pairs"]]
+        else:
+            return []
 
     def search_pairs(self, search_query: str) -> list[TokenPair]:
         """
@@ -66,13 +72,19 @@ class DexscreenerClient:
             Response as list of TokenPair model
         """
         resp = self._client.request("GET", f"dex/search/?q={search_query}")
-
-        return [TokenPair(**pair) for pair in resp["pairs"]]
+        
+        if resp["pairs"]:
+            return [TokenPair(**pair) for pair in resp["pairs"]]
+        else:
+            return []
 
     async def search_pairs_async(self, search_query: str) -> list[TokenPair]:
         """
         Async version of `search_pairs`
         """
         resp = await self._client.request_async("GET", f"dex/search/?q={search_query}")
-
-        return [TokenPair(**pair) for pair in resp["pairs"]]
+        
+        if resp["pairs"]:
+            return [TokenPair(**pair) for pair in resp["pairs"]]
+        else:
+            return []

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -18,16 +18,20 @@ class DexscreenerClient:
             Response as TokenPair model
         """
         resp = self._client.request("GET", f"dex/pairs/{chain}/{address}")
-
-        return TokenPair(**resp["pair"])
+        if resp["pair"]:
+            return TokenPair(**resp["pair"])
+        else:
+            pass #returns None for now but owner might want to raise Error
 
     async def get_token_pair_async(self, chain: str, address: str) -> TokenPair:
         """
         Async version of `get_token_pair`
         """
         resp = await self._client.request_async("GET", f"dex/pairs/{chain}/{address}")
-
-        return TokenPair(**resp["pair"])
+        if resp["pair"]:
+            return TokenPair(**resp["pair"])
+        else:
+            pass
 
     def get_token_pairs(self, address: str) -> list[TokenPair]:
         """

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -1,12 +1,12 @@
 from .models import TokenPair
 from .http_client import HttpClient
-
+from typing import Optional
 
 class DexscreenerClient:
     def __init__(self):
         self._client: HttpClient = HttpClient(100, 60)
 
-    def get_token_pair(self, chain: str, address: str) -> TokenPair:
+    def get_token_pair(self, chain: str, address: str) -> Optional[TokenPair]:
         """
         Fetch a pair on the provided chain id
 
@@ -23,7 +23,7 @@ class DexscreenerClient:
         else:
             pass #returns None for now but owner might want to raise Error
 
-    async def get_token_pair_async(self, chain: str, address: str) -> TokenPair:
+    async def get_token_pair_async(self, chain: str, address: str) -> Optional[TokenPair]:
         """
         Async version of `get_token_pair`
         """


### PR DESCRIPTION
Functions returning pairs need not to be changed given it returns [] which is expected. Functions returning pair needs to decide whether to return None or raising Error