### PR TITLE
Add support for fetching multiple pair addresses in a single request (up to 30)

### DIFF
--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -1,12 +1,12 @@
 from .models import TokenPair
 from .http_client import HttpClient
-from typing import Optional
+from typing import List, Union, Optional
 
 class DexscreenerClient:
     def __init__(self):
         self._client: HttpClient = HttpClient(100, 60)
 
-    def get_token_pair(self, chain: str, address: str) -> Optional[TokenPair]:
+    def get_token_pair(self, chain: str, address: Union[str,List[str]] ) -> Union[Optional[TokenPair], List[TokenPair] ]:
         """
         Fetch a pair on the provided chain id
 
@@ -17,15 +17,31 @@ class DexscreenerClient:
         :return:
             Response as TokenPair model
         """
-        resp = self._client.request("GET", f"dex/pairs/{chain}/{address}")
-        return TokenPair(**resp["pair"]) if resp["pair"] else None
+        if isinstance(address,str):
+            resp = self._client.request("GET", f"dex/pairs/{chain}/{address}")
+            return TokenPair(**resp["pair"]) if resp["pair"] else None
+        elif isinstance(address,list):
+            if len(address) > 30 :
+                raise ValueError("The maximum number of addresses allowed is 30");
+            resp = self._client.request("GET",f"dex/pairs/{chain}/{','.join(address)}")
+            print(resp);
+            return [TokenPair(**pair) for pair in resp.get("pairs", [])]
 
-    async def get_token_pair_async(self, chain: str, address: str) -> Optional[TokenPair]:
+        
+
+    async def get_token_pair_async(self, chain: str, address: Union[str,List[str]] ) -> Union[Optional[TokenPair], List[TokenPair] ]:
         """
         Async version of `get_token_pair`
         """
-        resp = await self._client.request_async("GET", f"dex/pairs/{chain}/{address}")        
-        return TokenPair(**resp["pair"]) if resp["pair"] else None
+        if isinstance(address,str):
+            resp = await self._client.request_async("GET", f"dex/pairs/{chain}/{address}")
+            return TokenPair(**resp["pair"]) if resp["pair"] else None
+        elif isinstance(address,list):
+            if len(address) > 30 :
+                raise ValueError("The maximum number of addresses allowed is 30");
+            resp = await self._client.request_async("GET",f"dex/pairs/{chain}/{','.join(address)}")
+            
+            return [TokenPair(**pair) for pair in resp.get("pairs", [])]
 
     def get_token_pairs(self, address: str) -> list[TokenPair]:
         """

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -1,12 +1,12 @@
 from .models import TokenPair
 from .http_client import HttpClient
-from typing import List, Union, Optional
+from typing import Optional, Iterable, List
 
 class DexscreenerClient:
     def __init__(self):
         self._client: HttpClient = HttpClient(100, 60)
 
-    def get_token_pair(self, chain: str, address: Union[str,List[str]] ) -> Union[Optional[TokenPair], List[TokenPair] ]:
+    def get_token_pair(self, chain: str, address: str) -> Optional[TokenPair]:
         """
         Fetch a pair on the provided chain id
 
@@ -17,32 +17,43 @@ class DexscreenerClient:
         :return:
             Response as TokenPair model
         """
-        if isinstance(address,str):
-            resp = self._client.request("GET", f"dex/pairs/{chain}/{address}")
-            return TokenPair(**resp["pair"]) if resp["pair"] else None
-        elif isinstance(address,list):
-            if len(address) > 30 :
-                raise ValueError("The maximum number of addresses allowed is 30");
-            resp = self._client.request("GET",f"dex/pairs/{chain}/{','.join(address)}")
-            print(resp);
-            return [TokenPair(**pair) for pair in resp.get("pairs", [])]
+        resp = self._client.request("GET", f"dex/pairs/{chain}/{address}")
+        return TokenPair(**resp["pair"]) if resp["pair"] else None
 
-        
-
-    async def get_token_pair_async(self, chain: str, address: Union[str,List[str]] ) -> Union[Optional[TokenPair], List[TokenPair] ]:
+    async def get_token_pair_async(self, chain: str, address: str) -> Optional[TokenPair]:
         """
         Async version of `get_token_pair`
         """
-        if isinstance(address,str):
-            resp = await self._client.request_async("GET", f"dex/pairs/{chain}/{address}")
-            return TokenPair(**resp["pair"]) if resp["pair"] else None
-        elif isinstance(address,list):
-            if len(address) > 30 :
-                raise ValueError("The maximum number of addresses allowed is 30");
-            resp = await self._client.request_async("GET",f"dex/pairs/{chain}/{','.join(address)}")
-            
-            return [TokenPair(**pair) for pair in resp.get("pairs", [])]
+        resp = await self._client.request_async("GET", f"dex/pairs/{chain}/{address}")        
+        return TokenPair(**resp["pair"]) if resp["pair"] else None
 
+    def get_token_pair_list(self, chain: str, addresses: Iterable[str]) -> List[TokenPair]:
+        """
+        Fetch multiple pairs on the provided chain id
+
+        https://api.dexscreener.com/latest/dex/pairs/ethereum/0xC2aDdA861F89bBB333c90c492cB837741916A225,0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387
+        
+        :param chain: Chain id
+        :param addresses: Iterable of token addresses (up to 30)
+        :return:
+            Response as list of TokenPair models
+        """
+        addresses_list = list(addresses)
+        if len(addresses_list) > 30:
+            raise ValueError("The maximum number of addresses allowed is 30.")
+        resp = self._client.request("GET", f"dex/pairs/{chain}/{','.join(addresses_list)}")
+        return [TokenPair(**pair) for pair in resp.get("pairs", [])]
+
+    async def get_token_pair_list_async(self, chain: str, addresses: Iterable[str]) -> List[TokenPair]:
+        """
+        Async version of `get_token_pairs`
+        """
+        addresses_list = list(addresses)
+        if len(addresses_list) > 30:
+            raise ValueError("The maximum number of addresses allowed is 30.")
+        resp = await self._client.request_async("GET", f"dex/pairs/{chain}/{','.join(addresses_list)}")
+        return [TokenPair(**pair) for pair in resp.get("pairs", [])]    
+    
     def get_token_pairs(self, address: str) -> list[TokenPair]:
         """
         Get pairs matching base token address

--- a/main.py
+++ b/main.py
@@ -1,16 +1,18 @@
 from dexscreener import DexscreenerClient
-
 import asyncio
-
 
 async def main():
     client = DexscreenerClient()
 
+    pair = await client.get_token_pair_async("ethereum", [
+    	"0xC2aDdA861F89bBB333c90c492cB837741916A225",
+    	"0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387"])
+    
     pair = await client.get_token_pair_async("harmony", "0xcd818813f038a4d1a27c84d24d74bbc21551fa83")
 
     pairs = await client.get_token_pairs_async("0x2170Ed0880ac9A755fd29B2688956BD959F933F8")
 
     search = await client.search_pairs_async("WBTC")
-
+    
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/main.py
+++ b/main.py
@@ -4,15 +4,17 @@ import asyncio
 async def main():
     client = DexscreenerClient()
 
-    pair = await client.get_token_pair_async("ethereum", [
+    pair = await client.get_token_pair_list_async("ethereum", (
     	"0xC2aDdA861F89bBB333c90c492cB837741916A225",
-    	"0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387"])
+    	"0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387") );
+    
     
     pair = await client.get_token_pair_async("harmony", "0xcd818813f038a4d1a27c84d24d74bbc21551fa83")
 
     pairs = await client.get_token_pairs_async("0x2170Ed0880ac9A755fd29B2688956BD959F933F8")
 
     search = await client.search_pairs_async("WBTC")
+    
     
 
 asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
Dexscreen API allows fetching up to 30 pair addresses in a single request.

[API Documentation Reference](https://docs.dexscreener.com/api/reference#:~:text=separated%20pair%20addresses-,(up%20to%2030%20addresses),-E.g.%3A%200xAbc1)

* Updated the get_token_pair and get_token_pair_async methods in the DexscreenerClient class to handle both single and multiple pair addresses.

```
multiple_pairs = await client.get_token_pair_async("ethereum", [
        "0xC2aDdA861F89bBB333c90c492cB837741916A225",
        "0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387"
    ])
```