### PR TITLE
Feat: add support for /tokens/v1 and /token-pairs/v1 endpoints with sync/async clients

### DIFF
--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -178,4 +178,14 @@ class DexscreenerClient:
         Get token information for multiple tokens by chain and addresses
         https://api.dexscreener.com/tokens/v1/{chainId}/{tokenAddresses}
         """
-        pass
+        if len(token_addresses) > 30:
+            raise ValueError("The maximum number of addresses allowed is 30.")
+
+        csv_addresses = ",".join(token_addresses)
+
+        # NOTE: this endpoint supports 300rpm however this is is not implemented, see: https://docs.dexscreener.com/api/reference#get-tokens-v1-chainid-tokenaddresses
+        # TODO: Implement 300rpm
+        resp = self._client_60rpm.request(
+            "GET", f"tokens/v1/{chain_id}/{csv_addresses}"
+        )
+        print(resp)

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -173,12 +173,16 @@ class DexscreenerClient:
         resp = await self._client_300rpm.request_async("GET", f"dex/search/?q={search_query}")        
         return [TokenPair(**pair) for pair in resp.get("pairs", [])]
 
-    def get_tokens_info(
+    def get_pairs_by_token_addresses(
         self, chain_id: str, token_list: Iterable[str]
     ) -> list[TokenPair]:
         """
         Get token information for multiple tokens by chain and addresses
-        https://api.dexscreener.com/tokens/v1/{chainId}/{tokenAddresses}
+
+        :param chain_id: Chain id eg: solana
+        :param token_list: Iterable of token addresses (up to 30) eg: [0x2170Ed0880ac9A755fd29B2688956BD959F933F8, 0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387]
+        :return:
+            Response as list of TokenPair model
         """
         token_list_list = list(token_list)
         if len(token_list_list) > 30:
@@ -193,11 +197,16 @@ class DexscreenerClient:
         )
         return [TokenPair(**pair) for pair in resp]
 
-    async def get_tokens_info_async(
+    async def get_pairs_by_token_addresses_async(
         self, chain_id: str, token_list: Iterable[str]
     ) -> list[TokenPair]:
         """
-        Async version of `get_tokens_info`
+        Async version of `get_pairs_by_token_addresses`
+
+        :param chain_id: Chain id eg: solana
+        :param token_list: Iterable of token addresses (up to 30) eg: [0x2170Ed0880ac9A755fd29B2688956BD959F933F8, 0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387]
+        :return:
+            Response as list of TokenPair model
         """
         token_list_list = list(token_list)
         if len(token_list_list) > 30:

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -217,3 +217,30 @@ class DexscreenerClient:
             "GET", f"tokens/v1/{chain_id}/{csv_addresses}"
         )
         return [TokenPair(**pair) for pair in resp]
+
+    def get_token_pairs_v1(self, chain_id: str, token_address: str) -> list[TokenPair]:
+        """
+        Get token pairs by token address
+
+        https://api.dexscreener.com/token-pairs/v1/{chainId}/{tokenAddress}
+
+        :param chain_id: Chain id eg: solana
+        :param token_address: Token address eg: JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN
+        :return:
+            Response as list of TokenPair model
+        """
+        resp = self._client_60rpm.request(
+            "GET", f"token-pairs/v1/{chain_id}/{token_address}"
+        )
+        return [TokenPair(**pair) for pair in resp]
+
+    async def get_token_pairs_v1_async(
+        self, chain_id: str, token_address: str
+    ) -> list[TokenPair]:
+        """
+        Async version of `get_token_pairs_v1`
+        """
+        resp = await self._client_60rpm.request_async(
+            "GET", f"token-pairs/v1/{chain_id}/{token_address}"
+        )
+        return [TokenPair(**pair) for pair in resp]

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -172,3 +172,10 @@ class DexscreenerClient:
         """
         resp = await self._client_300rpm.request_async("GET", f"dex/search/?q={search_query}")        
         return [TokenPair(**pair) for pair in resp.get("pairs", [])]
+
+    def get_tokens_info(self, chain_id: str, token_addresses: Iterable[str]):
+        """
+        Get token information for multiple tokens by chain and addresses
+        https://api.dexscreener.com/tokens/v1/{chainId}/{tokenAddresses}
+        """
+        pass

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -173,19 +173,38 @@ class DexscreenerClient:
         resp = await self._client_300rpm.request_async("GET", f"dex/search/?q={search_query}")        
         return [TokenPair(**pair) for pair in resp.get("pairs", [])]
 
-    def get_tokens_info(self, chain_id: str, token_addresses: Iterable[str]):
+    def get_tokens_info(
+        self, chain_id: str, token_list: Iterable[str]
+    ) -> list[TokenPair]:
         """
         Get token information for multiple tokens by chain and addresses
         https://api.dexscreener.com/tokens/v1/{chainId}/{tokenAddresses}
         """
-        if len(token_addresses) > 30:
+        token_list_list = list(token_list)
+        if len(token_list_list) > 30:
             raise ValueError("The maximum number of addresses allowed is 30.")
 
-        csv_addresses = ",".join(token_addresses)
+        csv_addresses = ",".join(token_list_list)  # TODO: improve validation
 
         # NOTE: this endpoint supports 300rpm however this is is not implemented, see: https://docs.dexscreener.com/api/reference#get-tokens-v1-chainid-tokenaddresses
         # TODO: Implement 300rpm
         resp = self._client_60rpm.request(
             "GET", f"tokens/v1/{chain_id}/{csv_addresses}"
         )
-        print(resp)
+        return [TokenPair(**pair) for pair in resp]
+
+    async def get_tokens_info_async(
+        self, chain_id: str, token_list: Iterable[str]
+    ) -> list[TokenPair]:
+        """
+        Async version of `get_tokens_info`
+        """
+        token_list_list = list(token_list)
+        if len(token_list_list) > 30:
+            raise ValueError("The maximum number of addresses allowed is 30.")
+
+        csv_addresses = ",".join(token_list_list)
+        resp = await self._client_60rpm.request_async(
+            "GET", f"tokens/v1/{chain_id}/{csv_addresses}"
+        )
+        return [TokenPair(**pair) for pair in resp]

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -5,9 +5,16 @@ import json
 
 
 class DexscreenerClient:
+    BASE_URL = "https://api.dexscreener.com"
+
     def __init__(self) -> None:
-        self._client_60rpm: HttpClient = HttpClient(60, 60, base_url="https://api.dexscreener.com")
-        self._client_300rpm: HttpClient = HttpClient(300, 60, base_url="https://api.dexscreener.com/latest")
+        self._client_60rpm: HttpClient = HttpClient(60, 60, base_url=self.BASE_URL)
+        self._client_300rpm_root: HttpClient = HttpClient(
+            300, 60, base_url=self.BASE_URL
+        )
+        self._client_300rpm: HttpClient = HttpClient(
+            300, 60, base_url=f"{self.BASE_URL}/latest"
+        )
 
     def get_latest_token_profiles(self) -> list[TokenInfo]:
         """
@@ -190,9 +197,7 @@ class DexscreenerClient:
 
         csv_addresses = ",".join(token_list_list)  # TODO: improve validation
 
-        # NOTE: this endpoint supports 300rpm however this is is not implemented, see: https://docs.dexscreener.com/api/reference#get-tokens-v1-chainid-tokenaddresses
-        # TODO: Implement 300rpm
-        resp = self._client_60rpm.request(
+        resp = self._client_300rpm_root.request(
             "GET", f"tokens/v1/{chain_id}/{csv_addresses}"
         )
         return [TokenPair(**pair) for pair in resp]
@@ -213,7 +218,7 @@ class DexscreenerClient:
             raise ValueError("The maximum number of addresses allowed is 30.")
 
         csv_addresses = ",".join(token_list_list)
-        resp = await self._client_60rpm.request_async(
+        resp = await self._client_300rpm_root.request_async(
             "GET", f"tokens/v1/{chain_id}/{csv_addresses}"
         )
         return [TokenPair(**pair) for pair in resp]
@@ -229,7 +234,7 @@ class DexscreenerClient:
         :return:
             Response as list of TokenPair model
         """
-        resp = self._client_60rpm.request(
+        resp = self._client_300rpm_root.request(
             "GET", f"token-pairs/v1/{chain_id}/{token_address}"
         )
         return [TokenPair(**pair) for pair in resp]
@@ -240,7 +245,7 @@ class DexscreenerClient:
         """
         Async version of `get_token_pairs_v1`
         """
-        resp = await self._client_60rpm.request_async(
+        resp = await self._client_300rpm_root.request_async(
             "GET", f"token-pairs/v1/{chain_id}/{token_address}"
         )
         return [TokenPair(**pair) for pair in resp]

--- a/dexscreener/client.py
+++ b/dexscreener/client.py
@@ -1,7 +1,7 @@
-from .models import TokenPair, TokenInfo, OrderInfo
+from typing import Iterable, List, Optional
+
 from .http_client import HttpClient
-from typing import Optional, Iterable, List
-import json
+from .models import OrderInfo, TokenInfo, TokenPair
 
 
 class DexscreenerClient:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
-from dexscreener import DexscreenerClient
 import asyncio
+
+from dexscreener import DexscreenerClient
+
 
 async def main():
     client = DexscreenerClient()
@@ -9,18 +11,37 @@ async def main():
     boosted_tokens = client.get_latest_boosted_tokens()
 
     most_active_tokens = client.get_tokens_most_active()
-    
-    paid_of_orders = client.get_orders_paid_of_token("solana", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
 
-    pair = await client.get_token_pair_async("harmony", "0xcd818813f038a4d1a27c84d24d74bbc21551fa83")
+    paid_of_orders = client.get_orders_paid_of_token(
+        "solana", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    )
 
-    pairs = await client.get_token_pairs_async("0x2170Ed0880ac9A755fd29B2688956BD959F933F8")
+    pair = await client.get_token_pair_async(
+        "harmony", "0xcd818813f038a4d1a27c84d24d74bbc21551fa83"
+    )
 
-    pairs = await client.get_token_pair_list_async("ethereum", (
-    	"0xC2aDdA861F89bBB333c90c492cB837741916A225",
-    	"0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387"))
+    pairs = await client.get_token_pairs_async(
+        "0x2170Ed0880ac9A755fd29B2688956BD959F933F8"
+    )
+
+    pairs = await client.get_token_pair_list_async(
+        "ethereum",
+        (
+            "0xC2aDdA861F89bBB333c90c492cB837741916A225",
+            "0x7BeA39867e4169DBe237d55C8242a8f2fcDcc387",
+        ),
+    )
 
     search = await client.search_pairs_async("WBTC")
-    
+
+    pairs = await client.get_token_pairs_v1_async(
+        "solana", "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN"
+    )
+
+    search = await client.get_pairs_by_token_addresses_async(
+        "solana",
+        ("JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",),
+    )
+
 
 asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
This PR changes implements the the following methods:

1. **`get_pairs_by_token_addresses(chain_id, token_list)`**
   - Endpoint: `/tokens/v1/{chainId}/{tokenAddresses}`
   - Supports up to 30 token addresses per request
   - Rate limit: 300rpm
   - Both sync and async versions

2. **`get_token_pairs_v1(chain_id, token_address)`**
   - Endpoint: `/token-pairs/v1/{chainId}/{tokenAddress}`
   - Get trading pools for a specific token address
   - Rate limit: 300rpm
---
This adheres to the following references: 
https://docs.dexscreener.com/api/reference#get-token-pairs-v1-chainid-tokenaddress
https://docs.dexscreener.com/api/reference#get-tokens-v1-chainid-tokenaddresses
---
examples have been provided in./main.py

Said endpoints support 300rpm requests but aren't after `/latest/` which had a 300rpm client, therefore a new client instance was made in the class, now the 3 clients take the _base url_ from a class level constant.

As a side note I use ruff for formatting so the style might be a bit different.